### PR TITLE
Fix: Cards have Equal Size

### DIFF
--- a/style.css
+++ b/style.css
@@ -769,6 +769,7 @@ button.mixitup-control-active {
   box-shadow: rgba(0, 0, 0, 0.18) 0px 2px 4px;
   padding: 1rem;
   border-radius: 10px;
+  height: auto !important;
 }
 
 .card-top {


### PR DESCRIPTION
# Description
The Mentioned Boxes in the grid now have equal size
![image](https://github.com/rascui/website/assets/91955358/23b47909-0c81-4c4e-962a-67762483edb6)

fixes:
#8 

Code overrides the default swiper library such that our cards have equal height now