### PR TITLE
variable undefined causing no highlighting of active nav links

### DIFF
--- a/script.js
+++ b/script.js
@@ -158,7 +158,7 @@ window.onload = calcScrollValue;
 
 // active menu 
 
-let menuLi = document.querySelectorAll("header ul li a");
+let menuLi = document.querySelectorAll("nav ul li a");
 let section = document.querySelectorAll('section');
 
 function activeMenu(){


### PR DESCRIPTION
This PR addresses #43 

It changes the selector to point to <nav> instead of <header> (which is not existent, and thus causing the undefined error)

After fixing
![image](https://github.com/rascui/website/assets/64256342/c08dd129-46ba-4467-a56c-718dc2d1bb4d)
In the above screenshot one can see, that I'm currently on the `About` section and the navbar highlights the correct nav-item.

Thanks